### PR TITLE
fixed olsrlinkview.py

### DIFF
--- a/scripts/olsrlinkview.py
+++ b/scripts/olsrlinkview.py
@@ -130,7 +130,7 @@ class NodeTextInfoThread(threading.Thread,Stoppable):
             c.setopt(pycurl.CONNECTTIMEOUT, 1)
             c.setopt(pycurl.TIMEOUT, 1)
             c.setopt(pycurl.NOSIGNAL, 1)
-            c.setopt(pycurl.URL, "http://node-%d:2006/links" %(self._nodeId))
+            c.setopt(pycurl.URL, "http://node-%d:2006/lin" %(self._nodeId))
             c.setopt(pycurl.WRITEFUNCTION, self._processInfo)
 
             try:


### PR DESCRIPTION
Since [07da147](https://github.com/OLSR/olsrd/commit/07da147cf9fb908e6a043bfe692d0344f1601613) commit OLSR txtinfo allows 3 character abbreviations. In more recent versions of txtinfo plugin, http://node-X:2006/links is depreciated and returns 404 error - "/lin" should be used instead.