### PR TITLE
fixed demo-init, extending $PATH

### DIFF
--- a/scripts/demo-init
+++ b/scripts/demo-init
@@ -238,7 +238,7 @@ usage()
 }
 
 
-export PATH=$PATH:/sbin:/usr/sbin
+export PATH=$PATH:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 starttime=
 


### PR DESCRIPTION
for software compiled from sources (for example OLSRd), the binary is added by default to /usr/local/sbin