### PR TITLE
fix emanegentrasportxml in rules.mk

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -71,8 +71,8 @@ endif
 
 $(PLATFORMDEPS): .%-dep:%
 	mkdir .emanegentransportxml && \
+	 emanegentransportxml ./$< -o .emanegentransportxml && \
 	 cd .emanegentransportxml &&   \
-	 emanegentransportxml ../$< && \
 	 for i in $$(ls *.xml); do chmod g-w,u-w $$i; cp -f $$i ..; done && \
 	 cd .. && \
 	 rm -rf .emanegentransportxml


### PR DESCRIPTION
This PR fixed #29. 

The problem is caused by the nem.xml and platform.xml being in different dir. So we can build in the current dir and use the output parm in emanegentransportxml to generate output in .emanegentransportxml.